### PR TITLE
Fixes rtv

### DIFF
--- a/pkgs/development/python-modules/coveralls/default.nix
+++ b/pkgs/development/python-modules/coveralls/default.nix
@@ -2,11 +2,13 @@
 , lib
 , fetchPypi
 , mock
-, pytest_27
+, pytest
+, pytestrunner
 , sh
 , coverage
 , docopt
 , requests
+, urllib3
 , git
 }:
 
@@ -24,7 +26,8 @@ buildPythonPackage rec {
   buildInputs = [
     mock
     sh
-    pytest_27
+    pytest
+    pytestrunner
     git
   ];
 
@@ -39,6 +42,7 @@ buildPythonPackage rec {
     coverage
     docopt
     requests
+    urllib3
   ];
 
   meta = {

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi
-, coverage, tornado, mock, nose, psutil, pysocks }:
+, pytest, mock, tornado, pyopenssl, cryptography
+, idna, certifi, ipaddress, pysocks }:
 
 buildPythonPackage rec {
   pname = "urllib3";
@@ -22,11 +23,12 @@ buildPythonPackage rec {
 
   doCheck = false;
 
-  buildInputs = [ coverage tornado mock nose psutil pysocks ];
+  buildInputs = [ pytest mock tornado ];
+  propagatedBuildInputs = [ pyopenssl cryptography idna certifi ipaddress pysocks ];
 
   meta = with stdenv.lib; {
-    description = "A Python library for Dropbox's HTTP-based Core and Datastore APIs";
-    homepage = https://www.dropbox.com/developers/core/docs;
+    description = "Powerful, sanity-friendly HTTP client for Python";
+    homepage = https://github.com/shazow/urllib3;
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I found `rtv` fails to build on nixos unstable channel, so I try to fix these packages to make `rtv` builds again.

Thanks!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

